### PR TITLE
Starting Conditions

### DIFF
--- a/StartingConditions
+++ b/StartingConditions
@@ -1,0 +1,17 @@
+int main()
+
+{   
+
+    //wait_for_light(light);
+
+    shut_down_in(119);
+
+    enable_servos();
+
+
+
+    //Start of actions--------------------------------
+    compcodepart1();
+    
+    //Align with pipe and black tape
+    move(-1500, 2000);


### PR DESCRIPTION
Make sure that the waitforlight command is uncommented at the start of the competition.